### PR TITLE
Feature custom username

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -8,6 +8,7 @@
 # Server Settings:
 
 Nick = YourBotName
+User = YourBotsUsername
 Server = irc.freenode.net
 ServerPassword = 
 Port = 6667

--- a/org/jibble/socnet/Configuration.java
+++ b/org/jibble/socnet/Configuration.java
@@ -26,6 +26,7 @@ public class Configuration implements java.io.Serializable {
     public int port;
     public String serverPassword;
     public String nick;
+    public String user;
     public HashSet channelSet;
     
     public int outputWidth;
@@ -70,6 +71,7 @@ public class Configuration implements java.io.Serializable {
         port = getInt("Port");
         serverPassword = getString("ServerPassword");
         nick = getString("Nick");
+        user = getString("User");
         channelSet = getSet("ChannelSet");
         
         outputWidth = getInt("OutputWidth");

--- a/org/jibble/socnet/SocialNetworkBot.java
+++ b/org/jibble/socnet/SocialNetworkBot.java
@@ -288,7 +288,7 @@ public class SocialNetworkBot extends PircBot {
         SocialNetworkBot bot = new SocialNetworkBot(config);
         bot.setVerbose(config.verbose);
         bot.setName(config.nick);
-        bot.setLogin("piespy");
+        bot.setLogin(config.user);
         bot.setVersion(VERSION + " http://www.jibble.org/piespy/");
         
         try {


### PR DESCRIPTION
Adds the option for the user to define the username, in case that would be useful to them. 

This could be useful for users connecting to a bouncer or any server that requires a specific username (rather than the default "piespy").